### PR TITLE
Add enumerateKeysAndObjectsWithIndexUsingBlock method

### DIFF
--- a/OrderedDictionary/OrderedDictionary.h
+++ b/OrderedDictionary/OrderedDictionary.h
@@ -47,6 +47,8 @@
 - (NSEnumerator *)reverseKeyEnumerator;
 /** Returns an enumerator for backwards traversal of the dictionary objects. */
 - (NSEnumerator *)reverseObjectEnumerator;
+/** Enumerates keys ands objects with index using block. */
+- (void)enumerateKeysAndObjectsWithIndexUsingBlock:(void (^)(id key, id obj, NSUInteger idx, BOOL *stop))block;
 
 @end
 

--- a/OrderedDictionary/OrderedDictionary.m
+++ b/OrderedDictionary/OrderedDictionary.m
@@ -141,6 +141,13 @@
     return [OrderedDictionaryReverseObjectEnumerator enumeratorWithKeys:_keys values:_values];
 }
 
+- (void)enumerateKeysAndObjectsWithIndexUsingBlock:(void (^)(id key, id obj, NSUInteger idx, BOOL *stop))block
+{
+    [_keys enumerateObjectsUsingBlock:^(id key, NSUInteger idx, BOOL *stop) {
+        block(key, _values[key], idx, stop);
+    }];
+}
+
 - (id)keyAtIndex:(NSUInteger)index
 {    
     return _keys[index];


### PR DESCRIPTION
Hi, this is a small Pull Request to add an enumeration method using block much like the [already existing one](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSDictionary_Class/Reference/Reference.html#//apple_ref/occ/instm/NSDictionary/enumerateKeysAndObjectsUsingBlock:) but with an extra argument, the index.
