### PR TITLE
Add a sort-aware insertObject 

### DIFF
--- a/OrderedDictionary/OrderedDictionary.h
+++ b/OrderedDictionary/OrderedDictionary.h
@@ -82,6 +82,8 @@
 
 /** Inserts an object at a specific index in the dictionary. */
 - (void)insertObject:(id)object forKey:(id)key atIndex:(NSUInteger)index;
+/** Inserts an object, sorting by the indicated selector. */
+- (NSUInteger)insertObject:(id)object forKey:(id)key selector:(SEL)comparator;
 /** Replace an object at a specific index in the dictionary. */
 - (void)replaceObjectAtIndex:(NSUInteger)index withObject:(id)object;
 - (void)setObject:(id)object atIndexedSubscript:(NSUInteger)index;

--- a/OrderedDictionary/OrderedDictionary.m
+++ b/OrderedDictionary/OrderedDictionary.m
@@ -266,6 +266,24 @@
     [_mutableValues insertObject:object atIndex:index];
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+- (NSUInteger)insertObject:(id)object forKey:(id)key selector:(SEL)comparator
+{
+    [self removeObjectForKey:key];
+    NSUInteger index;
+    for(index = 0; index < [_mutableKeys count]; ++index) {
+        NSComparisonResult result = (NSComparisonResult) [key performSelector:comparator withObject:[_mutableKeys objectAtIndex: index]];
+        if(result <= 0) {
+            break;
+        }
+    }
+    [_mutableKeys insertObject:key atIndex:index];
+    [_mutableValues insertObject:object atIndex:index];
+    return index;
+}
+#pragma clang diagnostic pop
+
 - (void)replaceObjectAtIndex:(NSUInteger)index withObject:(id)object
 {
     _mutableValues[index] = object;


### PR DESCRIPTION
This allows you to build a MutableOrderedDictionary without first pre-sorting.

            NSArray * myObjects = @[ ..., MyObjects, ... ];
            MutableOrderedDictionary *dict = [MutableOrderedDictionary dictionary];
            for (MyObject *obj in myObjects) {
                [dict insertObject:obj forKey:obj.name selector:@selector(caseInsensitiveCompare:)];
            }

NOTE: this will not sort an existing unordered dictionary; it only sorts the inserted key. 