### PR TITLE
remove warnings when building with XCode 9

### DIFF
--- a/OrderedDictionary.podspec.json
+++ b/OrderedDictionary.podspec.json
@@ -17,7 +17,7 @@
   "source_files": "OrderedDictionary",
   "requires_arc": true,
   "platforms": {
-    "ios": "4.3",
+    "ios": "6.0",
     "osx": "10.6",
     "tvos": "9.0",
     "watchos": "2.0"


### PR DESCRIPTION
Fix warnings like below:
  - 'objectForKeyedSubscript:' is only available on iOS 6.0 or newer
  - 'setObject:forKeyedSubscript:' is only available on iOS 6.0 or newer
  - 'NSOrderedSet' is partial: introduced in iOS 5.0
  - 'decodeObjectOfClass:forKey:' is only available on iOS 6.0 or newer
....
and so on.