### PR TITLE
Setting a keyed subscript to nil should remove the key

### DIFF
--- a/OrderedDictionary/OrderedDictionary.m
+++ b/OrderedDictionary/OrderedDictionary.m
@@ -480,7 +480,14 @@
 
 - (void)setObject:(id)object forKeyedSubscript:(id)key
 {
-    [self setObject:object forKey:key];
+    if (object)
+    {
+        [self setObject:object forKey:key];
+    }
+    else
+    {
+        [self removeObjectForKey:key];
+    }
 }
 
 @end


### PR DESCRIPTION
This is the same behaviour as NSMutableDictionary